### PR TITLE
Implement `update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,39 @@ UserItem.atomically.create_or_plus(columns, values, on_duplicate_update_columns)
 
 
 ### pay_all
+
 Reduce the quantity of items and return how many rows and updated if all of them is enough.
 Do nothing and return zero if any of them is not enough.
 
 Example:
 ```rb
 user.user_items.atomically.pay_all({ item1.id => 4, item2.id => 3 }, [:quantity], primary_key: :item_id)
+```
+
+### update
+
+Updates the attributes of the model from the passed-in hash and saves the record. The difference between this method and [ActiveRecord#update](https://apidock.com/rails/ActiveRecord/Persistence/update) is that it will add extra WHERE conditions to prevent race condition.
+
+Example:
+```rb
+class Arena < ApplicationRecord
+  def atomically_close!
+    atomically.update(closed_at: Time.now)
+  end
+
+  def close!
+    update(closed_at: Time.now)
+  end
+end
+```
+```sql
+# arena.atomically_close!
+UPDATE `arenas` SET `arenas`.`closed_at` = '2018-11-27 03:44:25', `updated_at` = '2018-11-27 03:44:25'
+WHERE `arenas`.`id` = 1752 AND `arenas`.`closed_at` IS NULL
+
+# arena.close!
+UPDATE `arenas` SET `arenas`.`closed_at` = '2018-11-27 03:44:25', `updated_at` = '2018-11-27 03:44:25'
+WHERE `arenas`.`id` = 1752
 ```
 
 ## Development

--- a/atomically.gemspec
+++ b/atomically.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "mysql2", ">= 0.3"
   spec.add_development_dependency "pluck_all", ">= 2.0.3"
-  spec.add_development_dependency "timecop", "~> 0.8.2"
+  spec.add_development_dependency "timecop", "~> 0.9.1"
 
   spec.add_dependency "activerecord", ">= 3"
   spec.add_dependency "activerecord-import", ">= 0.27.0"

--- a/atomically.gemspec
+++ b/atomically.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "mysql2", ">= 0.3"
   spec.add_development_dependency "pluck_all", ">= 2.0.3"
+  spec.add_development_dependency "timecop", "~> 0.8.2"
 
   spec.add_dependency "activerecord", ">= 3"
   spec.add_dependency "activerecord-import", ">= 0.27.0"

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -9,6 +9,8 @@ group :test do
   end
   gem "simplecov"
   gem "codeclimate-test-reporter", "~> 1.0.0"
+  gem "pluck_all", ">= 2.0.3"
+  gem "timecop", "~> 0.9.1"
 end
 
 gemspec :path => "../"

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -9,6 +9,8 @@ group :test do
   end
   gem "simplecov"
   gem "codeclimate-test-reporter", "~> 1.0.0"
+  gem "pluck_all", ">= 2.0.3"
+  gem "timecop", "~> 0.9.1"
 end
 
 gemspec :path => "../"

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -9,6 +9,8 @@ group :test do
   end
   gem "simplecov"
   gem "codeclimate-test-reporter", "~> 1.0.0"
+  gem "pluck_all", ">= 2.0.3"
+  gem "timecop", "~> 0.9.1"
 end
 
 gemspec :path => "../"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -9,6 +9,8 @@ group :test do
   end
   gem "simplecov"
   gem "codeclimate-test-reporter", "~> 1.0.0"
+  gem "pluck_all", ">= 2.0.3"
+  gem "timecop", "~> 0.9.1"
 end
 
 gemspec :path => "../"

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -9,6 +9,8 @@ group :test do
   end
   gem "simplecov"
   gem "codeclimate-test-reporter", "~> 1.0.0"
+  gem "pluck_all", ">= 2.0.3"
+  gem "timecop", "~> 0.9.1"
 end
 
 gemspec :path => "../"

--- a/lib/atomically/active_record/extension.rb
+++ b/lib/atomically/active_record/extension.rb
@@ -11,4 +11,8 @@ class ActiveRecord::Base
   def self.atomically
     Atomically::QueryService.new(self)
   end
+
+  def atomically
+    Atomically::QueryService.new(self.class, model: self)
+  end
 end

--- a/lib/atomically/patches/clear_attribute_changes.rb
+++ b/lib/atomically/patches/clear_attribute_changes.rb
@@ -1,0 +1,17 @@
+module ActiveModel
+  module Dirty
+    private
+
+    alias_method :attributes_changed_by_setter, :changed_attributes # :nodoc:
+
+    # Force an attribute to have a particular "before" value
+    def set_attribute_was(attr, old_value)
+      attributes_changed_by_setter[attr] = old_value
+    end
+
+    # Remove changes information for the provided attributes.
+    def clear_attribute_changes(attributes) # :doc:
+      attributes_changed_by_setter.except!(*attributes)
+    end
+  end
+end

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -38,6 +38,14 @@ class Atomically::QueryService
                 .update_all(update_sqls.join(', '))
   end
 
+  def update(attrs, from: :not_set)
+    open_update_all_scope do
+      attrs.each do |column, value|
+        where(column => (from == :not_set ? @model[column] : from)).update(column => value)
+      end
+    end
+  end
+
   private
 
   def on_duplicate_key_plus_sql( columns)

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -39,7 +39,7 @@ class Atomically::QueryService
   end
 
   def update(attrs, from: :not_set)
-    update_and_return_number_of_updated_rows(attrs, from: from) == 1
+    update_and_return_number_of_updated_rows(attrs, from) == 1
   end
 
   private
@@ -56,7 +56,7 @@ class Atomically::QueryService
     @klass.connection.quote(value)
   end
 
-  def update_and_return_number_of_updated_rows(attrs, from: :not_set)
+  def update_and_return_number_of_updated_rows(attrs, from)
     model = @model
     return open_update_all_scope do
       update(updated_at: Time.now)

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -3,7 +3,7 @@
 require 'activerecord-import'
 require 'rails_or'
 require 'atomically/update_all_scope'
-require 'atomically/patches/clear_attribute_changes' if not ActiveRecord::Base.private_method_defined?(:clear_attribute_changes)
+require 'atomically/patches/clear_attribute_changes' if not ActiveModel::Dirty.method_defined?(:clear_attribute_changes) and not ActiveModel::Dirty.private_method_defined?(:clear_attribute_changes)
 require 'atomically/patches/none' if not ActiveRecord::Base.respond_to?(:none)
 require 'atomically/patches/from' if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.0.0')
 

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -59,8 +59,10 @@ class Atomically::QueryService
   def update_and_return_number_of_updated_rows(attrs, from: :not_set)
     model = @model
     return open_update_all_scope do
+      update(updated_at: Time.now)
       attrs.each do |column, value|
-        where(column => (from == :not_set ? model[column] : from)).update(column => value)
+        old_value = (from == :not_set ? model[column] : from)
+        where(column => old_value).update(column => value) if old_value != value
       end
     end
   end

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -39,11 +39,7 @@ class Atomically::QueryService
   end
 
   def update(attrs, from: :not_set)
-    open_update_all_scope do
-      attrs.each do |column, value|
-        where(column => (from == :not_set ? @model[column] : from)).update(column => value)
-      end
-    end
+    update_and_return_number_of_updated_rows(attrs, from: from) == 1
   end
 
   private
@@ -58,6 +54,15 @@ class Atomically::QueryService
 
   def sanitize(value)
     @klass.connection.quote(value)
+  end
+
+  def update_and_return_number_of_updated_rows(attrs, from: :not_set)
+    model = @model
+    return open_update_all_scope do
+      attrs.each do |column, value|
+        where(column => (from == :not_set ? model[column] : from)).update(column => value)
+      end
+    end
   end
 
   def open_update_all_scope(&block)

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -7,7 +7,7 @@ require 'atomically/patches/none' if not ActiveRecord::Base.respond_to?(:none)
 require 'atomically/patches/from' if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.0.0')
 
 class Atomically::QueryService
-  def initialize(klass, relation: nil, model: nil, &block)
+  def initialize(klass, relation: nil, model: nil)
     @klass = klass
     @relation = relation || @klass
     @model = model
@@ -46,7 +46,7 @@ class Atomically::QueryService
 
   private
 
-  def on_duplicate_key_plus_sql( columns)
+  def on_duplicate_key_plus_sql(columns)
     columns.lazy.map(&method(:quote_column)).map{|s| "#{s} = #{s} + VALUES(#{s})" }.force.join(', ')
   end
 

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -39,7 +39,9 @@ class Atomically::QueryService
   end
 
   def update(attrs, from: :not_set)
-    update_and_return_number_of_updated_rows(attrs, from) == 1
+    success = update_and_return_number_of_updated_rows(attrs, from) == 1
+    assign_without_changes(attrs) if success
+    return success
   end
 
   private
@@ -72,5 +74,10 @@ class Atomically::QueryService
     scope = UpdateAllScope.new(model: @model)
     scope.instance_exec(&block)
     return scope.do_query!
+  end
+
+  def assign_without_changes(attributes)
+    @model.assign_attributes(attributes)
+    @model.send(:clear_attribute_changes, attributes.keys)
   end
 end

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -3,6 +3,7 @@
 require 'activerecord-import'
 require 'rails_or'
 require 'atomically/update_all_scope'
+require 'atomically/patches/clear_attribute_changes' if not ActiveRecord::Base.private_method_defined?(:clear_attribute_changes)
 require 'atomically/patches/none' if not ActiveRecord::Base.respond_to?(:none)
 require 'atomically/patches/from' if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.0.0')
 

--- a/lib/atomically/update_all_scope.rb
+++ b/lib/atomically/update_all_scope.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class UpdateAllScope
+  def initialize(model: nil, relation: nil)
+    @queries = []
+    @relation = relation || model.class.where(id: model.id)
+  end
+
+  def where(*args)
+    @relation = @relation.where(*args)
+    return self
+  end
+
+  def update(query, *binding_values)
+    args = binding_values.size > 0 ? [[query, *binding_values]] : [query]
+    @queries << klass.send(:sanitize_sql_for_assignment, *args)
+    return self
+  end
+
+  def do_query!
+    return 0 if @queries.empty?
+
+    return @relation.update_all(@queries.join(','))
+  end
+
+  def klass
+    @relation.klass
+  end
+end

--- a/lib/atomically/update_all_scope.rb
+++ b/lib/atomically/update_all_scope.rb
@@ -19,7 +19,6 @@ class UpdateAllScope
 
   def do_query!
     return 0 if @queries.empty?
-
     return @relation.update_all(@queries.join(','))
   end
 

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define do
 
   create_table :items, force: true do |t|
     t.string :name, null: false
+    t.string :desc, null: false, default: ''
     t.timestamps null: false
   end
 end
@@ -31,8 +32,8 @@ users = User.create([
 ])
 
 items = Item.create([
-  { name: 'bomb' },
-  { name: 'water gun' },
+  { name: 'bomb', desc: 'An explosive weapon.' },
+  { name: 'water gun', desc: 'A type of toy gun designed to shoot water.' },
   { name: 'flame thrower' },
 ])
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ end
 
 require 'lib/patches'
 require 'lib/seeds'
+require 'timecop'
 
 def in_sandbox
   ActiveRecord::Base.transaction do

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -4,12 +4,31 @@ class UpdateTest < Minitest::Test
   def setup
   end
 
-  def test_update_name
+  def test_update_attribute
     item = Item.find_by(name: 'bomb')
 
     in_sandbox do
-      assert_equal true, item.atomically.update(name: 'bomb2')
-      assert_equal 'bomb2', Item.find_by(id: item.id).name
+      Timecop.freeze(item.updated_at + 1.day) do
+        assert_equal true, item.atomically.update(name: 'bomb2')
+
+        new_item = Item.find_by(id: item.id)
+        assert_equal 'bomb2', new_item.name
+        assert_equal item.updated_at + 1.day, new_item.updated_at
+      end
+    end
+  end
+
+  def test_update_attribute_to_same_value
+    item = Item.find_by(name: 'bomb')
+
+    in_sandbox do
+      Timecop.freeze(item.updated_at + 1.day) do
+        assert_equal true, item.atomically.update(name: 'bomb')
+
+        new_item = Item.find_by(id: item.id)
+        assert_equal 'bomb', new_item.name
+        assert_equal item.updated_at + 1.day, new_item.updated_at
+      end
     end
   end
 end

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -12,7 +12,9 @@ class UpdateTest < Minitest::Test
         assert_equal true, @item.atomically.update(name: 'unknown')
 
         new_item = Item.find_by(id: @item.id)
+        assert_equal 'unknown', @item.name
         assert_equal 'unknown', new_item.name
+        assert_equal 'An explosive weapon.', @item.desc
         assert_equal 'An explosive weapon.', new_item.desc
         assert_in_delta @item.updated_at, new_item.updated_at, 1.day
       end
@@ -26,7 +28,9 @@ class UpdateTest < Minitest::Test
         assert_equal false, @item.atomically.update(name: 'unknown')
 
         new_item = Item.find_by(id: @item.id)
+        assert_equal 'bomb', @item.name
         assert_equal 'super bomb', new_item.name
+        assert_equal 'An explosive weapon.', @item.desc
         assert_equal 'An explosive weapon.', new_item.desc
         assert_in_delta @item.updated_at, new_item.updated_at, 0.day
       end
@@ -39,7 +43,9 @@ class UpdateTest < Minitest::Test
         assert_equal true, @item.atomically.update(name: 'bomb')
 
         new_item = Item.find_by(id: @item.id)
+        assert_equal 'bomb', @item.name
         assert_equal 'bomb', new_item.name
+        assert_equal 'An explosive weapon.', @item.desc
         assert_equal 'An explosive weapon.', new_item.desc
         assert_in_delta @item.updated_at, new_item.updated_at, 1.day
       end
@@ -52,7 +58,9 @@ class UpdateTest < Minitest::Test
         assert_equal false, @item.atomically.update({ name: 'unknown' }, { from: 'super bomb' })
 
         new_item = Item.find_by(id: @item.id)
+        assert_equal 'bomb', @item.name
         assert_equal 'bomb', new_item.name
+        assert_equal 'An explosive weapon.', @item.desc
         assert_equal 'An explosive weapon.', new_item.desc
         assert_in_delta @item.updated_at, new_item.updated_at, 0.day
       end
@@ -66,7 +74,9 @@ class UpdateTest < Minitest::Test
         assert_equal true, @item.atomically.update({ name: 'unknown' }, { from: 'super bomb' })
 
         new_item = Item.find_by(id: @item.id)
+        assert_equal 'unknown', @item.name
         assert_equal 'unknown', new_item.name
+        assert_equal 'An explosive weapon.', @item.desc
         assert_equal 'An explosive weapon.', new_item.desc
         assert_in_delta @item.updated_at, new_item.updated_at, 1.day
       end
@@ -79,7 +89,9 @@ class UpdateTest < Minitest::Test
         assert_equal true, @item.atomically.update(name: 'unknown', desc: 'no description')
 
         new_item = Item.find_by(id: @item.id)
+        assert_equal 'unknown', @item.name
         assert_equal 'unknown', new_item.name
+        assert_equal 'no description', @item.desc
         assert_equal 'no description', new_item.desc
         assert_in_delta @item.updated_at, new_item.updated_at, 1.day
       end

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -9,10 +9,11 @@ class UpdateTest < Minitest::Test
   def test_update_attribute
     in_sandbox do
       Timecop.freeze(@future) do
-        assert_equal true, @item.atomically.update(name: 'bomb2')
+        assert_equal true, @item.atomically.update(name: 'unknown')
 
         new_item = Item.find_by(id: @item.id)
-        assert_equal 'bomb2', new_item.name
+        assert_equal 'unknown', new_item.name
+        assert_equal 'An explosive weapon.', new_item.desc
         assert_equal @future, new_item.updated_at
       end
     end
@@ -25,6 +26,7 @@ class UpdateTest < Minitest::Test
 
         new_item = Item.find_by(id: @item.id)
         assert_equal 'bomb', new_item.name
+        assert_equal 'An explosive weapon.', new_item.desc
         assert_equal @future, new_item.updated_at
       end
     end
@@ -33,11 +35,25 @@ class UpdateTest < Minitest::Test
   def test_update_attribute_with_custom_from
     in_sandbox do
       Timecop.freeze(@future) do
-        assert_equal false, @item.atomically.update({ name: 'bomb2' }, { from: 'water gun' })
+        assert_equal false, @item.atomically.update({ name: 'unknown' }, { from: 'water gun' })
 
         new_item = Item.find_by(id: @item.id)
         assert_equal 'bomb', new_item.name
+        assert_equal 'An explosive weapon.', new_item.desc
         assert_equal @item.updated_at, new_item.updated_at
+      end
+    end
+  end
+
+  def test_update_multiple_attributes
+    in_sandbox do
+      Timecop.freeze(@future) do
+        assert_equal true, @item.atomically.update(name: 'unknown', desc: 'no description')
+
+        new_item = Item.find_by(id: @item.id)
+        assert_equal 'unknown', new_item.name
+        assert_equal 'no description', new_item.desc
+        assert_equal @future, new_item.updated_at
       end
     end
   end

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -29,4 +29,16 @@ class UpdateTest < Minitest::Test
       end
     end
   end
+
+  def test_update_attribute_with_custom_from
+    in_sandbox do
+      Timecop.freeze(@future) do
+        assert_equal false, @item.atomically.update({ name: 'bomb2' }, { from: 'water gun' })
+
+        new_item = Item.find_by(id: @item.id)
+        assert_equal 'bomb', new_item.name
+        assert_equal @item.updated_at, new_item.updated_at
+      end
+    end
+  end
 end

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -2,32 +2,30 @@ require 'test_helper'
 
 class UpdateTest < Minitest::Test
   def setup
+    @item = Item.find_by(name: 'bomb')
+    @future = @item.updated_at + 1.day
   end
 
   def test_update_attribute
-    item = Item.find_by(name: 'bomb')
-
     in_sandbox do
-      Timecop.freeze(item.updated_at + 1.day) do
-        assert_equal true, item.atomically.update(name: 'bomb2')
+      Timecop.freeze(@future) do
+        assert_equal true, @item.atomically.update(name: 'bomb2')
 
-        new_item = Item.find_by(id: item.id)
+        new_item = Item.find_by(id: @item.id)
         assert_equal 'bomb2', new_item.name
-        assert_equal item.updated_at + 1.day, new_item.updated_at
+        assert_equal @future, new_item.updated_at
       end
     end
   end
 
   def test_update_attribute_to_same_value
-    item = Item.find_by(name: 'bomb')
-
     in_sandbox do
-      Timecop.freeze(item.updated_at + 1.day) do
-        assert_equal true, item.atomically.update(name: 'bomb')
+      Timecop.freeze(@future) do
+        assert_equal true, @item.atomically.update(name: 'bomb')
 
-        new_item = Item.find_by(id: item.id)
+        new_item = Item.find_by(id: @item.id)
         assert_equal 'bomb', new_item.name
-        assert_equal item.updated_at + 1.day, new_item.updated_at
+        assert_equal @future, new_item.updated_at
       end
     end
   end

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class UpdateTest < Minitest::Test
+  def setup
+  end
+
+  def test_update_name
+    item = Item.find_by(name: 'bomb')
+
+    in_sandbox do
+      assert_equal true, item.atomically.update(name: 'bomb2')
+      assert_equal 'bomb2', Item.find_by(id: item.id).name
+    end
+  end
+end

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -55,7 +55,7 @@ class UpdateTest < Minitest::Test
   def test_update_attribute_with_custom_from
     in_sandbox do
       Timecop.freeze(@future) do
-        assert_equal false, @item.atomically.update({ name: 'unknown' }, { from: 'super bomb' })
+        assert_equal false, @item.atomically.update({ name: 'unknown' }, from: 'super bomb')
 
         new_item = Item.find_by(id: @item.id)
         assert_equal 'bomb', @item.name
@@ -71,7 +71,7 @@ class UpdateTest < Minitest::Test
     in_sandbox do
       Timecop.freeze(@future) do
         assert_equal 1, Item.where(id: @item.id).update_all(name: 'super bomb')
-        assert_equal true, @item.atomically.update({ name: 'unknown' }, { from: 'super bomb' })
+        assert_equal true, @item.atomically.update({ name: 'unknown' }, from: 'super bomb')
 
         new_item = Item.find_by(id: @item.id)
         assert_equal 'unknown', @item.name


### PR DESCRIPTION
### update
Updates the attributes of the model from the passed-in hash and saves the record. The difference between this method and [ActiveRecord#update](https://apidock.com/rails/ActiveRecord/Persistence/update) is that it will add extra WHERE conditions to prevent race condition.

Example:
```rb
class Arena < ApplicationRecord
  def atomically_close!
    atomically.update(closed_at: Time.now)
  end

  def close!
    update(closed_at: Time.now)
  end
end
```
```sql
# arena.atomically_close!
UPDATE `arenas` SET `arenas`.`closed_at` = '2018-11-27 03:44:25', `updated_at` = '2018-11-27 03:44:25' 
WHERE `arenas`.`id` = 1752 AND `arenas`.`closed_at` IS NULL

# arena.close!
UPDATE `arenas` SET `arenas`.`closed_at` = '2018-11-27 03:44:25', `updated_at` = '2018-11-27 03:44:25' 
WHERE `arenas`.`id` = 1752
```
