### PR TITLE
Implement `update_all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ Example:
 user.user_items.atomically.pay_all({ item1.id => 4, item2.id => 3 }, [:quantity], primary_key: :item_id)
 ```
 
+### update_all _(expected_number, updates)_
+
+Behaves like [ActiveRecord::Relation#update_all](https://apidock.com/rails/ActiveRecord/Relation/update_all) but add an additional constrain that the number of affected rows equals to what you specify.
+
+#### Parameters
+ - `expected_number` - The number of rows that you expect to be updated.
+ - `updates` - A string, array, or hash representing the SET part of an SQL statement.
+
+#### Examples
+```rb
+User.where(id: [1, 2]).atomically.update_all(2, name: '')
+# => 2
+
+User.where(id: [1, 2, 3]).atomically.update_all(2, name: '')
+# => 0
+```
+
 ### update
 
 Updates the attributes of the model from the passed-in hash and saves the record. The difference between this method and [ActiveRecord#update](https://apidock.com/rails/ActiveRecord/Persistence/update) is that it will add extra WHERE conditions to prevent race condition.

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -35,8 +35,7 @@ class Atomically::QueryService
       next "#{column} = #{column} + #{value}"
     end
 
-    return query.where("(#{@klass.from(query).select('COUNT(*)').to_sql}) = ?", hash.size)
-                .update_all(update_sqls.join(', '))
+    return where_all_can_be_updated(query, hash.size).update_all(update_sqls.join(', '))
   end
 
   def update_all(expected_size, *args)

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -39,6 +39,10 @@ class Atomically::QueryService
                 .update_all(update_sqls.join(', '))
   end
 
+  def update_all(expected_size, *args)
+    where_all_can_be_updated(@relation, expected_size).update_all(*args)
+  end
+
   def update(attrs, from: :not_set)
     success = update_and_return_number_of_updated_rows(attrs, from) == 1
     assign_without_changes(attrs) if success
@@ -57,6 +61,10 @@ class Atomically::QueryService
 
   def sanitize(value)
     @klass.connection.quote(value)
+  end
+
+  def where_all_can_be_updated(query, expected_size)
+    query.where("(#{@klass.from(query.where('')).select('COUNT(*)').to_sql}) = ?", expected_size)
   end
 
   def update_and_return_number_of_updated_rows(attrs, from)

--- a/test/update_all_test.rb
+++ b/test/update_all_test.rb
@@ -6,8 +6,30 @@ class UpdateAllTest < Minitest::Test
 
   def test_update_all_on_klass
     in_sandbox do
-      Item.atomically.update_all(3, name: '')
+      assert_equal 3, Item.atomically.update_all(3, name: '')
       assert_equal ['', '', ''], Item.pluck(:name)
+    end
+  end
+
+  def test_update_all_on_relation
+    in_sandbox do
+      assert_equal 2, Item.where(id: [1, 2]).atomically.update_all(2, name: '')
+      assert_equal ['', '', 'flame thrower'], Item.pluck(:name)
+    end
+  end
+
+  def test_update_all_on_relation_with_wrong_expected_size
+    in_sandbox do
+      assert_equal 0, Item.where(id: [1, 2]).atomically.update_all(3, name: '')
+      assert_equal ['bomb', 'water gun', 'flame thrower'], Item.pluck(:name)
+    end
+  end
+
+  def test_update_all_on_relation_and_with_race_condition
+    in_sandbox do
+      assert_equal 1, Item.where(id: 1).update_all(id: -1)
+      assert_equal 0, Item.where(id: [1, 2]).atomically.update_all(2, name: '')
+      assert_equal ['bomb', 'water gun', 'flame thrower'], Item.pluck(:name)
     end
   end
 end

--- a/test/update_all_test.rb
+++ b/test/update_all_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class UpdateAllTest < Minitest::Test
+  def setup
+  end
+
+  def test_update_all_on_klass
+    in_sandbox do
+      Item.atomically.update_all(3, name: '')
+      assert_equal ['', '', ''], Item.pluck(:name)
+    end
+  end
+end


### PR DESCRIPTION
### update_all _(expected_number, updates)_

Behaves like [ActiveRecord::Relation#update_all](https://apidock.com/rails/ActiveRecord/Relation/update_all) but add an additional constrain that the number of affected rows equals to what you specify.

#### Parameters
 - `expected_number` - The number of rows that you expect to be updated.
 - `updates` - A string, array, or hash representing the SET part of an SQL statement.

#### Examples
```rb
User.where(id: [1, 2]).atomically.update_all(2, name: '')
# => 2

User.where(id: [1, 2, 3]).atomically.update_all(2, name: '')
# => 0
```
