### PR TITLE
Implement `update_all_and_get_ids`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Supports Rails 3.2, 4.2, 5.0, 5.1, 5.2.
    - [pay_all](#pay_all-hash-update_columns-primary_key-id)
    - [update_all](#update_all-expected_number-updates)
    - [update](#update-attrs-from-not_set)
+   - [update_all_and_get_ids](#update_all_and_get_ids-updates)
 3. [Development](#development)
 4. [Contributing](#contributing)
 5. [License](#license)
@@ -191,6 +192,33 @@ WHERE `arenas`.`id` = 1752 AND `arenas`.`closed_at` IS NULL
 # arena.close!
 UPDATE `arenas` SET `arenas`.`closed_at` = '2018-11-27 03:44:25', `updated_at` = '2018-11-27 03:44:25'
 WHERE `arenas`.`id` = 1752
+```
+
+---
+### update_all_and_get_ids _(updates)_
+
+Behaves like [ActiveRecord::Relation#update_all](https://apidock.com/rails/ActiveRecord/Relation/update_all), but return the ids array of updated records instead of the number of updated records.
+
+
+#### Parameters
+
+  - `updates` - A string, array, or hash representing the SET part of an SQL statement.
+
+#### Example
+
+```rb
+User.where(account: ['moon', 'wolf']).atomically.update_all_and_get_ids('money = money + 1')
+# => [254, 371]
+```
+
+#### SQL queries
+
+```sql
+BEGIN
+  SET @ids := NULL
+  UPDATE `users` SET money = money + 1 WHERE `users`.`account` IN ('moon', 'wolf') AND ((SELECT @ids := CONCAT_WS(',', `users`.`id`, @ids)))
+  SELECT @ids FROM DUAL
+COMMIT
 ```
 
 ## Development

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -56,7 +56,7 @@ class Atomically::QueryService
       @relation.where("(SELECT @id := CONCAT_WS(',', #{id_column}, @id))").update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
       ids = @klass.from(nil).pluck('@id').first
     end
-    return ids.try{|s| s.split(',').map(&:to_i).uniq.sort } # 將 id 從字串取出來 @id 的格式範例: '1,4,12'
+    return ids.try{|s| s.split(',').map(&:to_i).uniq.sort } || [] # 將 id 從字串取出來 @id 的格式範例: '1,4,12'
   end
 
   private

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -56,7 +56,7 @@ class Atomically::QueryService
       @relation.where("(SELECT @id := CONCAT_WS(',', #{id_column}, @id))").update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
       ids = @klass.from(nil).pluck('@id').first
     end
-    return ids.try{|s| s.split(',').map(&:to_i) } # 將 id 從字串取出來 @id 的格式範例: '1,4,12'
+    return ids.try{|s| s.split(',').map(&:to_i) }.uniq # 將 id 從字串取出來 @id 的格式範例: '1,4,12'
   end
 
   private

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -48,6 +48,16 @@ class Atomically::QueryService
     return success
   end
 
+  def update_all_and_get_ids(*args)
+    ids = nil
+    transaction do
+      connection.execute('SET @id := NULL')
+      where('(SELECT @id := CONCAT_WS(",", id, @id))').update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
+      ids = from(nil).pluck('@id').first
+    end
+    return ids.try{|s| s.split(',').map(&:to_i) } # 將 id 從字串取出來 @id 的格式範例: '1,4,12'
+  end
+
   private
 
   def on_duplicate_key_plus_sql(columns)

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -52,9 +52,9 @@ class Atomically::QueryService
     ids = nil
     id_column = "#{@klass.quoted_table_name}.#{quote_column(:id)}"
     @klass.transaction do
-      @relation.connection.execute('SET @id := NULL')
-      @relation.where("(SELECT @id := CONCAT_WS(',', #{id_column}, @id))").update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
-      ids = @klass.from(nil).pluck('@id').first
+      @relation.connection.execute('SET @ids := NULL')
+      @relation.where("(SELECT @ids := CONCAT_WS(',', #{id_column}, @ids))").update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
+      ids = @klass.from(nil).pluck('@ids').first
     end
     return ids.try{|s| s.split(',').map(&:to_i).uniq.sort } || [] # 將 id 從字串取出來 @id 的格式範例: '1,4,12'
   end

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -50,10 +50,10 @@ class Atomically::QueryService
 
   def update_all_and_get_ids(*args)
     ids = nil
-    transaction do
-      connection.execute('SET @id := NULL')
-      where('(SELECT @id := CONCAT_WS(",", id, @id))').update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
-      ids = from(nil).pluck('@id').first
+    @klass.transaction do
+      @relation.connection.execute('SET @id := NULL')
+      @relation.where('(SELECT @id := CONCAT_WS(",", id, @id))').update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
+      ids = @klass.from(nil).pluck('@id').first
     end
     return ids.try{|s| s.split(',').map(&:to_i) } # 將 id 從字串取出來 @id 的格式範例: '1,4,12'
   end

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -50,9 +50,10 @@ class Atomically::QueryService
 
   def update_all_and_get_ids(*args)
     ids = nil
+    id_column = "#{@klass.quoted_table_name}.#{quote_column(:id)}"
     @klass.transaction do
       @relation.connection.execute('SET @id := NULL')
-      @relation.where('(SELECT @id := CONCAT_WS(",", id, @id))').update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
+      @relation.where("(SELECT @id := CONCAT_WS(',', #{id_column}, @id))").update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
       ids = @klass.from(nil).pluck('@id').first
     end
     return ids.try{|s| s.split(',').map(&:to_i) } # 將 id 從字串取出來 @id 的格式範例: '1,4,12'

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -56,7 +56,7 @@ class Atomically::QueryService
       @relation.where("(SELECT @id := CONCAT_WS(',', #{id_column}, @id))").update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
       ids = @klass.from(nil).pluck('@id').first
     end
-    return ids.try{|s| s.split(',').map(&:to_i) }.uniq # 將 id 從字串取出來 @id 的格式範例: '1,4,12'
+    return ids.try{|s| s.split(',').map(&:to_i).uniq.sort } # 將 id 從字串取出來 @id 的格式範例: '1,4,12'
   end
 
   private

--- a/test/update_all_and_get_ids_test.rb
+++ b/test/update_all_and_get_ids_test.rb
@@ -33,8 +33,16 @@ class UpdateAllAndGetIdsTest < Minitest::Test
   end
 
   def test_with_joins
+    skip if ActiveRecord::VERSION::MAJOR < 4 # join + update_all result in ambiguous column name in Rails 3
     in_sandbox do
       assert_equal [1, 2], Item.joins(:users).atomically.update_all_and_get_ids(name: '')
+      assert_equal ['', '', 'flame thrower'], Item.pluck(:name)
+    end
+  end
+
+  def test_with_joins_with_raw_string_args
+    in_sandbox do
+      assert_equal [1, 2], Item.joins(:users).atomically.update_all_and_get_ids('items.name = ""')
       assert_equal ['', '', 'flame thrower'], Item.pluck(:name)
     end
   end

--- a/test/update_all_and_get_ids_test.rb
+++ b/test/update_all_and_get_ids_test.rb
@@ -18,6 +18,13 @@ class UpdateAllAndGetIdsTest < Minitest::Test
     end
   end
 
+  def test_none
+    in_sandbox do
+      assert_equal [], Item.none.atomically.update_all_and_get_ids(name: '')
+      assert_equal ['bomb', 'water gun', 'flame thrower'], Item.pluck(:name)
+    end
+  end
+
   def test_where_by_name
     in_sandbox do
       assert_equal [2], Item.where(name: 'water gun').atomically.update_all_and_get_ids(name: '')

--- a/test/update_all_and_get_ids_test.rb
+++ b/test/update_all_and_get_ids_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class UpdateAllAndGetIdsTest < Minitest::Test
+  def setup
+  end
+
+  def test_update_all_and_get_ids_on_klass
+    in_sandbox do
+      assert_equal [3, 2, 1], Item.atomically.update_all_and_get_ids(name: '')
+      assert_equal ['', '', ''], Item.pluck(:name)
+    end
+  end
+
+  def test_update_all_on_relation
+    in_sandbox do
+      assert_equal [3, 1], Item.where(id: [1, 3]).atomically.update_all_and_get_ids(name: '')
+      assert_equal ['', 'water gun', ''], Item.pluck(:name)
+    end
+  end
+
+  def test_update_all_on_relation_and_with_race_condition
+    in_sandbox do
+      assert_equal 1, Item.where(id: 1).update_all(id: -1)
+      assert_equal [2], Item.where(id: [1, 2]).atomically.update_all_and_get_ids(name: '')
+      assert_equal ['bomb', '', 'flame thrower'], Item.pluck(:name)
+    end
+  end
+end

--- a/test/update_all_and_get_ids_test.rb
+++ b/test/update_all_and_get_ids_test.rb
@@ -4,21 +4,35 @@ class UpdateAllAndGetIdsTest < Minitest::Test
   def setup
   end
 
-  def test_update_all_and_get_ids_on_klass
+  def test_on_klass
     in_sandbox do
       assert_equal [3, 2, 1], Item.atomically.update_all_and_get_ids(name: '')
       assert_equal ['', '', ''], Item.pluck(:name)
     end
   end
 
-  def test_update_all_on_relation
+  def test_on_relation
     in_sandbox do
       assert_equal [3, 1], Item.where(id: [1, 3]).atomically.update_all_and_get_ids(name: '')
       assert_equal ['', 'water gun', ''], Item.pluck(:name)
     end
   end
 
-  def test_update_all_on_relation_and_with_race_condition
+  def test_where_by_name
+    in_sandbox do
+      assert_equal [2], Item.where(name: 'water gun').atomically.update_all_and_get_ids(name: '')
+      assert_equal ['bomb', '', 'flame thrower'], Item.pluck(:name)
+    end
+  end
+
+  def test_with_joins
+    in_sandbox do
+      assert_equal [2, 1], Item.joins(:users).atomically.update_all_and_get_ids(name: '')
+      assert_equal ['', '', 'flame thrower'], Item.pluck(:name)
+    end
+  end
+
+  def test_on_relation_and_with_race_condition
     in_sandbox do
       assert_equal 1, Item.where(id: 1).update_all(id: -1)
       assert_equal [2], Item.where(id: [1, 2]).atomically.update_all_and_get_ids(name: '')

--- a/test/update_all_and_get_ids_test.rb
+++ b/test/update_all_and_get_ids_test.rb
@@ -6,14 +6,14 @@ class UpdateAllAndGetIdsTest < Minitest::Test
 
   def test_on_klass
     in_sandbox do
-      assert_equal [3, 2, 1], Item.atomically.update_all_and_get_ids(name: '')
+      assert_equal [1, 2, 3], Item.atomically.update_all_and_get_ids(name: '')
       assert_equal ['', '', ''], Item.pluck(:name)
     end
   end
 
   def test_on_relation
     in_sandbox do
-      assert_equal [3, 1], Item.where(id: [1, 3]).atomically.update_all_and_get_ids(name: '')
+      assert_equal [1, 3], Item.where(id: [1, 3]).atomically.update_all_and_get_ids(name: '')
       assert_equal ['', 'water gun', ''], Item.pluck(:name)
     end
   end
@@ -27,7 +27,7 @@ class UpdateAllAndGetIdsTest < Minitest::Test
 
   def test_with_joins
     in_sandbox do
-      assert_equal [2, 1], Item.joins(:users).atomically.update_all_and_get_ids(name: '')
+      assert_equal [1, 2], Item.joins(:users).atomically.update_all_and_get_ids(name: '')
       assert_equal ['', '', 'flame thrower'], Item.pluck(:name)
     end
   end


### PR DESCRIPTION

### update_all_and_get_ids _(updates)_

Behaves like [ActiveRecord::Relation#update_all](https://apidock.com/rails/ActiveRecord/Relation/update_all), but return the ids array of updated records instead of the number of updated records.


#### Parameters

  - `updates` - A string, array, or hash representing the SET part of an SQL statement.

#### Example

```rb
User.where(account: ['moon', 'wolf']).atomically.update_all_and_get_ids('money = money + 1')
# => [254, 371]
```

#### SQL queries

```sql
BEGIN
  SET @ids := NULL
  UPDATE `users` SET money = money + 1 WHERE `users`.`account` IN ('moon', 'wolf') AND ((SELECT @ids := CONCAT_WS(',', `users`.`id`, @ids)))
  SELECT @ids FROM DUAL
COMMIT
```