### PR TITLE
Fix: Non-attribute arguments will be disallowed in Rails 6.0

### DIFF
--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -67,7 +67,7 @@ class Atomically::QueryService
     @klass.transaction do
       @relation.connection.execute('SET @ids := NULL')
       @relation.where("(SELECT @ids := CONCAT_WS(',', #{id_column}, @ids))").update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
-      ids = @klass.from(nil).pluck('@ids').first
+      ids = @klass.from(nil).pluck(Arel.sql('@ids')).first
     end
     return ids.try{|s| s.split(',').map(&:to_i).uniq.sort } || [] # 將 id 從字串取出來 @id 的格式範例: '1,4,12'
   end


### PR DESCRIPTION
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "@ids"
See: https://github.com/rails/rails/issues/32995