### PR TITLE
Fix: changed attributes are not updated when calling `atomically.update`

### DIFF
--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -53,7 +53,7 @@ class Atomically::QueryService
 
   def update(attrs, from: :not_set)
     success = update_and_return_number_of_updated_rows(attrs, from) == 1
-    assign_without_changes(attrs) if success
+    assign_without_changes(@model.changes.transform_values(&:second).merge(attrs)) if success
     return success
   end
 

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -118,12 +118,17 @@ class Atomically::QueryService
     query.where("(#{@klass.from(query.where('')).select('COUNT(*)').to_sql}) = ?", expected_size)
   end
 
-  def update_and_return_number_of_updated_rows(attrs, from)
+  def update_and_return_number_of_updated_rows(attrs, from_value)
     model = @model
     return open_update_all_scope do
       update(updated_at: Time.now)
+
+      model.changes.each do |column, (_old_value, new_value)|
+        update(column => new_value)
+      end
+
       attrs.each do |column, value|
-        old_value = (from == :not_set ? model[column] : from)
+        old_value = (from_value == :not_set ? model[column] : from_value)
         where(column => old_value).update(column => value) if old_value != value
       end
     end

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -53,7 +53,12 @@ class Atomically::QueryService
 
   def update(attrs, from: :not_set)
     success = update_and_return_number_of_updated_rows(attrs, from) == 1
-    assign_without_changes(@model.changes.transform_values(&:second).merge(attrs)) if success
+
+    if success
+      assign_without_changes(attrs)
+      @model.send(:clear_attribute_changes, @model.changes.keys)
+    end
+
     return success
   end
 

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -21,6 +21,22 @@ class UpdateTest < Minitest::Test
     end
   end
 
+  def test_update_attribute_when_there_are_changes
+    in_sandbox do
+      Timecop.freeze(@future) do
+        @item.desc = 'unknown weapon.'
+        assert_equal true, @item.atomically.update(name: 'unknown')
+
+        new_item = Item.find_by(id: @item.id)
+        assert_equal 'unknown', @item.name
+        assert_equal 'unknown', new_item.name
+        assert_equal 'unknown weapon.', @item.desc
+        assert_equal 'unknown weapon.', new_item.desc
+        assert_in_delta @item.updated_at, new_item.updated_at, 1.day
+      end
+    end
+  end
+
   def test_update_attribute_with_race_condition
     in_sandbox do
       Timecop.freeze(@future) do


### PR DESCRIPTION
## Reproduction Steps

```rb
user = User.take 
# => #<User id: 1, account: "tester" nickname: "peter">

user.nickname = 'new nickname'
user.atomically.update(account: 'new_tester')
# UPDATE `users` SET `users`.`updated_at` = '2020-09-01 04:14:25',`users`.`account` = 'new_tester' WHERE `users`.`id` = 421582 AND `users`.`account` = 'tester'

user.changes
 => {"nickname"=>["peter", "new nickname"]} 

user.save
# UPDATE `users` SET `nickname` = 'new nickname', `updated_at` = '2020-09-01 04:15:02' WHERE `users`.`id` = 421582
```