### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,6 +27,7 @@ jobs:
           # See: https://github.community/t/mysql2-segmentation-fault-at-0x0000000000000000/159283
           - 2.6
           - 2.7
+          - 3.0
         gemfile:
           - 3.2.gemfile
           - 4.2.gemfile
@@ -38,9 +39,19 @@ jobs:
           - gemfile: 3.2.gemfile
             ruby: 2.6
           - gemfile: 3.2.gemfile
+            ruby: 3.0
+          - gemfile: 3.2.gemfile
             ruby: 2.7
           - gemfile: 4.2.gemfile
             ruby: 2.7
+          - gemfile: 4.2.gemfile
+            ruby: 3.0
+          - gemfile: 5.0.gemfile
+            ruby: 3.0
+          - gemfile: 5.1.gemfile
+            ruby: 3.0
+          - gemfile: 5.2.gemfile
+            ruby: 3.0
           - gemfile: 6.0.gemfile
             ruby: 2.2
         include:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 All methods are defined in `Atomically::QueryService` instead of defining in `ActiveRecord` directly, in order not to pollute the model instance.
 
 ## Supports
-- Ruby 2.2 ~ 2.7
+- Ruby 2.2 ~ 2.7, 3.0
 - Rails 3.2, 4.2, 5.0, 5.1, 5.2, 6.0
 - MySQL, PostgreSQL
 

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'activerecord', '~> 4.2.0'
 
 group :test do
-  gem 'mysql2', '0.3.21' if %w[mysql makara_mysql].include?(ENV['DB'])
+  gem 'mysql2', '0.4.10' if %w[mysql makara_mysql].include?(ENV['DB'])
   gem 'pg', '~> 0.18' if %w[pg makara_pg].include?(ENV['DB'])
   gem 'makara', '~> 0.4.1' if %w[makara_mysql makara_pg].include?(ENV['DB'])
   gem 'simplecov', '< 0.18'

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'activerecord', '~> 5.0.0'
 
 group :test do
-  gem 'mysql2', '0.3.21' if %w[mysql makara_mysql].include?(ENV['DB'])
+  gem 'mysql2', '0.4.10' if %w[mysql makara_mysql].include?(ENV['DB'])
   gem 'pg', '~> 0.18' if %w[pg makara_pg].include?(ENV['DB'])
   gem 'makara', '~> 0.4.1' if %w[makara_mysql makara_pg].include?(ENV['DB'])
   gem 'simplecov', '< 0.18'

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'activerecord', '~> 5.1.0'
 
 group :test do
-  gem 'mysql2', '0.3.21' if %w[mysql makara_mysql].include?(ENV['DB'])
+  gem 'mysql2', '0.4.10' if %w[mysql makara_mysql].include?(ENV['DB'])
   gem 'pg', '~> 0.18' if %w[pg makara_pg].include?(ENV['DB'])
   gem 'makara', '~> 0.4.1' if %w[makara_mysql makara_pg].include?(ENV['DB'])
   gem 'simplecov', '< 0.18'

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -4,7 +4,7 @@ gem 'activerecord', '~> 6.0.0'
 
 group :test do
   gem 'mysql2', '0.5.1' if %w[mysql makara_mysql].include?(ENV['DB'])
-  gem 'pg', '~> 0.18' if %w[pg makara_pg].include?(ENV['DB'])
+  gem 'pg', '~> 1.1.4' if %w[pg makara_pg].include?(ENV['DB'])
   gem 'makara', '~> 0.4.1' if %w[makara_mysql makara_pg].include?(ENV['DB'])
   gem 'simplecov', '< 0.18'
   gem 'pluck_all', '>= 2.0.4'

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -4,7 +4,7 @@ gem 'activerecord', '~> 6.0.0'
 
 group :test do
   gem 'mysql2', '0.5.1' if %w[mysql makara_mysql].include?(ENV['DB'])
-  gem 'pg', '~> 1.2.3' if %w[pg makara_pg].include?(ENV['DB'])
+  gem 'pg', '~> 1.4.6' if %w[pg makara_pg].include?(ENV['DB'])
   gem 'makara', '~> 0.4.1' if %w[makara_mysql makara_pg].include?(ENV['DB'])
   gem 'simplecov', '< 0.18'
   gem 'pluck_all', '>= 2.0.4'

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -4,7 +4,7 @@ gem 'activerecord', '~> 6.0.0'
 
 group :test do
   gem 'mysql2', '0.5.1' if %w[mysql makara_mysql].include?(ENV['DB'])
-  gem 'pg', '~> 1.1.4' if %w[pg makara_pg].include?(ENV['DB'])
+  gem 'pg', '~> 1.2.3' if %w[pg makara_pg].include?(ENV['DB'])
   gem 'makara', '~> 0.4.1' if %w[makara_mysql makara_pg].include?(ENV['DB'])
   gem 'simplecov', '< 0.18'
   gem 'pluck_all', '>= 2.0.4'

--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -51,7 +51,8 @@ class Atomically::QueryService
     where_all_can_be_updated(@relation, expected_size).update_all(*args)
   end
 
-  def update(attrs, from: :not_set)
+  def update(attrs, options = {})
+    from = options[:from] || :not_set
     success = update_and_return_number_of_updated_rows(attrs, from) == 1
 
     if success

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,7 +38,10 @@ end
 def assert_queries(expected_count, event_key = 'sql.active_record')
   sqls = []
   subscriber = ActiveSupport::Notifications.subscribe(event_key) do |_, _, _, _, payload|
-    sqls << "  ● #{payload[:sql]}" if payload[:sql] !~ /\A(?:BEGIN TRANSACTION|COMMIT TRANSACTION|BEGIN|COMMIT)\z/i
+    next if payload[:sql].start_with?('PRAGMA table_info')
+    next if payload[:sql] =~ /\A(?:BEGIN TRANSACTION|COMMIT TRANSACTION|BEGIN|COMMIT)\z/i
+
+    sqls << "  ● #{payload[:sql]}"
   end
   yield
   if expected_count != sqls.size # show all sql queries if query count doesn't equal to expected count.


### PR DESCRIPTION
## unknown type name ‘my_bool’; did you mean ‘_Bool’?

If you encounter this:
Upgrade `mysql2` gem to ~> 0.4.10
See: https://github.com/brianmario/mysql2/issues/980

### Error messages:
```
Fetching mysql2 0.3.21
Installing mysql2 0.3.21 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

...

compiling client.c
client.c: In function ‘nogvl_read_query_result’:
client.c:439:3: error: unknown type name ‘my_bool’; did you mean ‘_Bool’?
  439 |   my_bool res = mysql_read_query_result(client);
      |   ^~~~~~~
      |   _Bool
client.c: In function ‘rb_query’:
```

## undefined symbol: rb_tainted_str_new2

If you encounter this:
Upgrade `pg` gem to ~> 1.2
See: https://github.com/ged/ruby-pg/pull/307

### Error messages:
```
/opt/hostedtoolcache/Ruby/3.2.2/x64/bin/ruby: symbol lookup error: /home/runner/work/atomically/atomically/vendor/bundle/ruby/3.2.0/gems/pg-1.1.4/lib/pg_ext.so: undefined symbol: rb_tainted_str_new2
```

## ‘rb_cData’ undeclared

If you encounter this:
Upgrade `pg` gem to ~> 1.4.6
See: https://github.com/ged/ruby-pg/issues/496

### Error messages:
```
pg_result.c:1590:65: error: ‘rb_cData’ undeclared (first use in this function)
1590 |         rb_cPGresult = rb_define_class_under( rb_mPG, "Result", rb_cData
);
      |                                                                 ^~~~~~~~
pg_result.c:1590:65: note: each undeclared identifier is reported only once for
each function it appears in
pg_result.c: At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been
intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have
been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may
have been intended to silence earlier diagnostics
make: *** [Makefile:248: pg_result.o] Error 1

make failed, exit code 2
```