### PR TITLE
Fix - `from(nil)` did not generate the expected SQL

### DIFF
--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -88,7 +88,7 @@ class Atomically::QueryService
     @klass.transaction do
       @relation.connection.execute('SET @ids := NULL')
       @relation.where("(SELECT @ids := CONCAT_WS(',', #{id_column}, @ids))").update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
-      ids = @klass.from(nil).pluck(Arel.sql('@ids')).first
+      ids = @klass.from(Arel.sql('DUAL')).pluck(Arel.sql('@ids')).first
     end
     return ids.try{|s| s.split(',').map(&:to_i).uniq.sort } || [] # 將 id 從字串取出來 @id 的格式範例: '1,4,12'
   end

--- a/test/update_all_and_get_ids_test.rb
+++ b/test/update_all_and_get_ids_test.rb
@@ -65,4 +65,15 @@ class UpdateAllAndGetIdsTest < Minitest::Test
       assert_equal ['bomb', '', 'flame thrower'], Item.order('id').pluck(:name)
     end
   end
+
+  def test_select_from_dual
+    skip if not Atomically::AdapterCheckService.new(UserItem).mysql?
+
+    in_sandbox do
+      assert_sqls(['SELECT @ids FROM DUAL']) do
+        assert_equal [1, 2], Item.joins(:users).atomically.update_all_and_get_ids('items.name = ""')
+        assert_equal ['', '', 'flame thrower'], Item.order('id').pluck(:name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In this commit:
https://github.com/rails/rails/commit/bdc5141652770fd227455681cde1f9899f55b0b9#diff-79b53b2602bf702bdd8ce677e096be6a6923a54236e17237c16068a510078683R869

Activerecord has modified the behavior of `from(nil)` where it no longer substitutes with `DUAL`, resulting in unexpected SQL generated.

While this behavior change still retrieves the data from `@ids` correctly, it causes the returned result to include many rows (the quantity is equivalent to the number of records in the table), thereby causing performance issues.