### PR TITLE
Fix: Use explicit expression in where condition

### DIFF
--- a/lib/atomically/query_service.rb
+++ b/lib/atomically/query_service.rb
@@ -87,7 +87,7 @@ class Atomically::QueryService
     id_column = quote_column_with_table(:id)
     @klass.transaction do
       @relation.connection.execute('SET @ids := NULL')
-      @relation.where("(SELECT @ids := CONCAT_WS(',', #{id_column}, @ids))").update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
+      @relation.where("((@ids := CONCAT_WS(',', #{id_column}, @ids)) IS NOT NULL)").update_all(*args) # 撈出有真的被更新的 id，用逗號串在一起
       ids = @klass.from(Arel.sql('DUAL')).pluck(Arel.sql('@ids')).first
     end
     return ids.try{|s| s.split(',').map(&:to_i).uniq.sort } || [] # 將 id 從字串取出來 @id 的格式範例: '1,4,12'


### PR DESCRIPTION
In MySQL 8.0 and later, using user variables in the `WHERE` condition may raise the error `Truncated incorrect DOUBLE value: 'id1,id2'` when `@ids` contains more than one ID.

The exact reason for this behavior is unclear, but using an explicit expression can resolve the issue. For example, the following approaches work fine:
```mysql
((@ids := CONCAT_WS(',', #{id_column}, @ids)) IS NOT NULL)
```

or

```mysql
COALESCE(@ids := CONCAT_WS(',', #{id_column}, @ids))
```

or

```mysql
!ISNULL(@ids := CONCAT_WS(',', #{id_column}, @ids))
```